### PR TITLE
[New Version] Update versions file to PHP 8.0.1

### DIFF
--- a/src/versions.php
+++ b/src/versions.php
@@ -2,6 +2,6 @@
 
 namespace WyriHaximus\FakePHPVersion;
 
-const FUTURE = '9.217.217';
-const CURRENT = '8.256.256';
-const ACTUAL = '8.0.0';
+const FUTURE = '9.217.218';
+const CURRENT = '8.256.260';
+const ACTUAL = '8.0.1';


### PR DESCRIPTION
With the release of PHP 8.0.1 this packages needs updating. So this PR will bump current to 8.256.260 and future to 9.217.218.