### PR TITLE
[New Version] Update versions file to PHP 8.0.1

### DIFF
--- a/src/versions.php
+++ b/src/versions.php
@@ -2,6 +2,6 @@
 
 namespace WyriHaximus\FakePHPVersion;
 
-const FUTURE = '9.217.223';
-const CURRENT = '8.256.264';
-const ACTUAL = '8.0.2';
+const FUTURE = '9.217.222';
+const CURRENT = '8.256.261';
+const ACTUAL = '8.0.1';


### PR DESCRIPTION
With the release of PHP 8.0.1 this packages needs updating. So this PR will bump current to 8.256.261 and future to 9.217.222.