### PR TITLE
[New Version] Update versions file to PHP 8.0.3

### DIFF
--- a/src/versions.php
+++ b/src/versions.php
@@ -2,6 +2,6 @@
 
 namespace WyriHaximus\FakePHPVersion;
 
-const FUTURE = '9.217.219';
-const CURRENT = '8.256.258';
-const ACTUAL = '8.0.2';
+const FUTURE = '9.217.226';
+const CURRENT = '8.256.265';
+const ACTUAL = '8.0.3';


### PR DESCRIPTION
With the release of PHP 8.0.3 this packages needs updating. So this PR will bump current to 8.256.265 and future to 9.217.226.