### PR TITLE
[New Version] Update versions file to PHP 8.0.6

### DIFF
--- a/src/versions.php
+++ b/src/versions.php
@@ -2,6 +2,6 @@
 
 namespace WyriHaximus\FakePHPVersion;
 
-const FUTURE = '9.217.227';
-const CURRENT = '8.256.271';
-const ACTUAL = '8.0.5';
+const FUTURE = '9.217.223';
+const CURRENT = '8.256.262';
+const ACTUAL = '8.0.6';


### PR DESCRIPTION
With the release of PHP 8.0.6 this packages needs updating. So this PR will bump current to 8.256.262 and future to 9.217.223.