### PR TITLE
[New Version] Update versions file to PHP 8.0.7

### DIFF
--- a/src/versions.php
+++ b/src/versions.php
@@ -2,6 +2,6 @@
 
 namespace WyriHaximus\FakePHPVersion;
 
-const FUTURE = '9.217.227';
-const CURRENT = '8.256.271';
-const ACTUAL = '1.0.0';
+const FUTURE = '9.217.231';
+const CURRENT = '8.256.291';
+const ACTUAL = '8.0.7';


### PR DESCRIPTION
With the release of PHP 8.0.7 this packages needs updating. So this PR will bump current to 8.256.291 and future to 9.217.231.