### PR TITLE
[New Version] Update versions file to PHP 8.0.8

### DIFF
--- a/src/versions.php
+++ b/src/versions.php
@@ -2,6 +2,6 @@
 
 namespace WyriHaximus\FakePHPVersion;
 
-const FUTURE = '9.217.231';
-const CURRENT = '8.256.263';
-const ACTUAL = '8.0.7';
+const FUTURE = '9.217.241';
+const CURRENT = '8.256.288';
+const ACTUAL = '8.0.8';


### PR DESCRIPTION
With the release of PHP 8.0.8 this packages needs updating. So this PR will bump current to 8.256.288 and future to 9.217.241.