### PR TITLE
[New Version] Update versions file to PHP 8.0.10

### DIFF
--- a/src/versions.php
+++ b/src/versions.php
@@ -2,6 +2,6 @@
 
 namespace WyriHaximus\FakePHPVersion;
 
-const FUTURE = '9.217.262';
-const CURRENT = '8.256.274';
-const ACTUAL = '8.0.9';
+const FUTURE = '9.217.257';
+const CURRENT = '8.256.286';
+const ACTUAL = '8.0.10';


### PR DESCRIPTION
With the release of PHP 8.0.10 this packages needs updating. So this PR will bump current to 8.256.286 and future to 9.217.257.