### PR TITLE
[New Version] Update versions file to PHP 8.0.11

### DIFF
--- a/src/versions.php
+++ b/src/versions.php
@@ -2,6 +2,6 @@
 
 namespace WyriHaximus\FakePHPVersion;
 
-const FUTURE = '9.217.257';
-const CURRENT = '8.256.286';
-const ACTUAL = '8.0.10';
+const FUTURE = '9.217.272';
+const CURRENT = '8.256.267';
+const ACTUAL = '8.0.11';


### PR DESCRIPTION
With the release of PHP 8.0.11 this packages needs updating. So this PR will bump current to 8.256.267 and future to 9.217.272.