### PR TITLE
[New Version] Update versions file to PHP 8.0.13

### DIFF
--- a/src/versions.php
+++ b/src/versions.php
@@ -2,6 +2,6 @@
 
 namespace WyriHaximus\FakePHPVersion;
 
-const FUTURE = '9.217.277';
-const CURRENT = '8.256.268';
-const ACTUAL = '8.0.12';
+const FUTURE = '9.217.282';
+const CURRENT = '8.256.308';
+const ACTUAL = '8.0.13';


### PR DESCRIPTION
With the release of PHP 8.0.13 this packages needs updating. So this PR will bump current to 8.256.308 and future to 9.217.282.