### PR TITLE
[New Version] Update versions file to PHP 8.1.0

### DIFF
--- a/src/versions.php
+++ b/src/versions.php
@@ -2,6 +2,6 @@
 
 namespace WyriHaximus\FakePHPVersion;
 
-const FUTURE = '9.217.282';
-const CURRENT = '8.256.308';
-const ACTUAL = '8.0.13';
+const FUTURE = '9.222.217';
+const CURRENT = '8.260.256';
+const ACTUAL = '8.1.0';


### PR DESCRIPTION
With the release of PHP 8.1.0 this packages needs updating. So this PR will bump current to 8.260.256 and future to 9.222.217.