### PR TITLE
[New Version] Update versions file to PHP 8.1.2

### DIFF
--- a/src/versions.php
+++ b/src/versions.php
@@ -2,6 +2,6 @@
 
 namespace WyriHaximus\FakePHPVersion;
 
-const FUTURE = '9.223.223';
-const CURRENT = '8.261.261';
-const ACTUAL = '8.1.1';
+const FUTURE = '9.227.227';
+const CURRENT = '8.266.265';
+const ACTUAL = '8.1.2';


### PR DESCRIPTION
With the release of PHP 8.1.2 this packages needs updating. So this PR will bump current to 8.266.265 and future to 9.227.227.