### PR TITLE
[New Version] Update versions file to PHP 8.1.3

### DIFF
--- a/src/versions.php
+++ b/src/versions.php
@@ -2,6 +2,6 @@
 
 namespace WyriHaximus\FakePHPVersion;
 
-const FUTURE = '9.227.227';
-const CURRENT = '8.266.265';
-const ACTUAL = '8.1.2';
+const FUTURE = '9.229.239';
+const CURRENT = '8.271.278';
+const ACTUAL = '8.1.3';


### PR DESCRIPTION
With the release of PHP 8.1.3 this packages needs updating. So this PR will bump current to 8.271.278 and future to 9.229.239.