### PR TITLE
[New Version] Update versions file to PHP 8.1.4

### DIFF
--- a/src/versions.php
+++ b/src/versions.php
@@ -2,6 +2,6 @@
 
 namespace WyriHaximus\FakePHPVersion;
 
-const FUTURE = '9.229.239';
-const CURRENT = '8.271.278';
-const ACTUAL = '8.1.3';
+const FUTURE = '9.233.233';
+const CURRENT = '8.273.287';
+const ACTUAL = '8.1.4';


### PR DESCRIPTION
With the release of PHP 8.1.4 this packages needs updating. So this PR will bump current to 8.273.287 and future to 9.233.233.