### PR TITLE
[New Version] Update versions file to PHP 8.1.5

### DIFF
--- a/src/versions.php
+++ b/src/versions.php
@@ -2,6 +2,6 @@
 
 namespace WyriHaximus\FakePHPVersion;
 
-const FUTURE = '9.233.233';
-const CURRENT = '8.273.287';
-const ACTUAL = '8.1.4';
+const FUTURE = '9.236.243';
+const CURRENT = '8.275.288';
+const ACTUAL = '8.1.5';


### PR DESCRIPTION
With the release of PHP 8.1.5 this packages needs updating. So this PR will bump current to 8.275.288 and future to 9.236.243.