### PR TITLE
[New Version] Update versions file to PHP 8.1.6

### DIFF
--- a/src/versions.php
+++ b/src/versions.php
@@ -2,6 +2,6 @@
 
 namespace WyriHaximus\FakePHPVersion;
 
-const FUTURE = '9.236.243';
-const CURRENT = '8.275.288';
-const ACTUAL = '8.1.5';
+const FUTURE = '9.237.260';
+const CURRENT = '8.280.293';
+const ACTUAL = '8.1.6';


### PR DESCRIPTION
With the release of PHP 8.1.6 this packages needs updating. So this PR will bump current to 8.280.293 and future to 9.237.260.