### PR TITLE
[New Version] Update versions file to PHP 8.1.7

### DIFF
--- a/src/versions.php
+++ b/src/versions.php
@@ -2,6 +2,6 @@
 
 namespace WyriHaximus\FakePHPVersion;
 
-const FUTURE = '9.237.260';
-const CURRENT = '8.280.293';
-const ACTUAL = '8.1.6';
+const FUTURE = '9.241.244';
+const CURRENT = '8.282.308';
+const ACTUAL = '8.1.7';


### PR DESCRIPTION
With the release of PHP 8.1.7 this packages needs updating. So this PR will bump current to 8.282.308 and future to 9.241.244.