### PR TITLE
[New Version] Update versions file to PHP 8.1.8

### DIFF
--- a/src/versions.php
+++ b/src/versions.php
@@ -2,6 +2,6 @@
 
 namespace WyriHaximus\FakePHPVersion;
 
-const FUTURE = '9.241.244';
-const CURRENT = '8.282.308';
-const ACTUAL = '8.1.7';
+const FUTURE = '9.244.273';
+const CURRENT = '8.287.306';
+const ACTUAL = '8.1.8';


### PR DESCRIPTION
With the release of PHP 8.1.8 this packages needs updating. So this PR will bump current to 8.287.306 and future to 9.244.273.