### PR TITLE
[New Version] Update versions file to PHP 8.1.9

### DIFF
--- a/src/versions.php
+++ b/src/versions.php
@@ -2,6 +2,6 @@
 
 namespace WyriHaximus\FakePHPVersion;
 
-const FUTURE = '9.244.273';
-const CURRENT = '8.287.306';
-const ACTUAL = '8.1.8';
+const FUTURE = '9.248.289';
+const CURRENT = '8.288.314';
+const ACTUAL = '8.1.9';


### PR DESCRIPTION
With the release of PHP 8.1.9 this packages needs updating. So this PR will bump current to 8.288.314 and future to 9.248.289.