### PR TITLE
[New Version] Update versions file to PHP 8.1.11

### DIFF
--- a/src/versions.php
+++ b/src/versions.php
@@ -2,6 +2,6 @@
 
 namespace WyriHaximus\FakePHPVersion;
 
-const FUTURE = '9.251.288';
-const CURRENT = '8.291.308';
-const ACTUAL = '8.1.10';
+const FUTURE = '9.252.295';
+const CURRENT = '8.292.346';
+const ACTUAL = '8.1.11';


### PR DESCRIPTION
With the release of PHP 8.1.11 this packages needs updating. So this PR will bump current to 8.292.346 and future to 9.252.295.