### PR TITLE
[New Version] Update versions file to PHP 8.1.13

### DIFF
--- a/src/versions.php
+++ b/src/versions.php
@@ -2,6 +2,6 @@
 
 namespace WyriHaximus\FakePHPVersion;
 
-const FUTURE = '9.254.264';
-const CURRENT = '8.295.304';
-const ACTUAL = '8.1.12';
+const FUTURE = '9.257.293';
+const CURRENT = '8.299.334';
+const ACTUAL = '8.1.13';


### PR DESCRIPTION
With the release of PHP 8.1.13 this packages needs updating. So this PR will bump current to 8.299.334 and future to 9.257.293.