### PR TITLE
[New Version] Update versions file to PHP 8.2.1

### DIFF
--- a/src/versions.php
+++ b/src/versions.php
@@ -2,6 +2,6 @@
 
 namespace WyriHaximus\FakePHPVersion;
 
-const FUTURE = '9.261.257';
-const CURRENT = '8.303.299';
-const ACTUAL = '8.2.0';
+const FUTURE = '9.265.262';
+const CURRENT = '8.309.307';
+const ACTUAL = '8.2.1';


### PR DESCRIPTION
With the release of PHP 8.2.1 this packages needs updating. So this PR will bump current to 8.309.307 and future to 9.265.262.