### PR TITLE
[New Version] Update versions file to PHP 8.2.2

### DIFF
--- a/src/versions.php
+++ b/src/versions.php
@@ -2,6 +2,6 @@
 
 namespace WyriHaximus\FakePHPVersion;
 
-const FUTURE = '9.265.262';
-const CURRENT = '8.309.307';
-const ACTUAL = '8.2.1';
+const FUTURE = '9.269.275';
+const CURRENT = '8.315.319';
+const ACTUAL = '8.2.2';


### PR DESCRIPTION
With the release of PHP 8.2.2 this packages needs updating. So this PR will bump current to 8.315.319 and future to 9.269.275.