### PR TITLE
[New Version] Update versions file to PHP 8.2.3

### DIFF
--- a/src/versions.php
+++ b/src/versions.php
@@ -2,6 +2,6 @@
 
 namespace WyriHaximus\FakePHPVersion;
 
-const FUTURE = '9.269.275';
-const CURRENT = '8.315.319';
-const ACTUAL = '8.2.2';
+const FUTURE = '9.279.284';
+const CURRENT = '8.317.327';
+const ACTUAL = '8.2.3';


### PR DESCRIPTION
With the release of PHP 8.2.3 this packages needs updating. So this PR will bump current to 8.317.327 and future to 9.279.284.