### PR TITLE
[New Version] Update versions file to PHP 8.2.5

### DIFF
--- a/src/versions.php
+++ b/src/versions.php
@@ -2,6 +2,6 @@
 
 namespace WyriHaximus\FakePHPVersion;
 
-const FUTURE = '9.289.295';
-const CURRENT = '8.319.325';
-const ACTUAL = '8.2.4';
+const FUTURE = '9.295.294';
+const CURRENT = '8.323.324';
+const ACTUAL = '8.2.5';


### PR DESCRIPTION
With the release of PHP 8.2.5 this packages needs updating. So this PR will bump current to 8.323.324 and future to 9.295.294.