### PR TITLE
[New Version] Update versions file to PHP 8.2.6

### DIFF
--- a/src/versions.php
+++ b/src/versions.php
@@ -2,6 +2,6 @@
 
 namespace WyriHaximus\FakePHPVersion;
 
-const FUTURE = '9.295.294';
-const CURRENT = '8.323.324';
-const ACTUAL = '8.2.5';
+const FUTURE = '9.305.301';
+const CURRENT = '8.327.347';
+const ACTUAL = '8.2.6';


### PR DESCRIPTION
With the release of PHP 8.2.6 this packages needs updating. So this PR will bump current to 8.327.347 and future to 9.305.301.