### PR TITLE
[New Version] Update versions file to PHP 8.2.8

### DIFF
--- a/src/versions.php
+++ b/src/versions.php
@@ -2,6 +2,6 @@
 
 namespace WyriHaximus\FakePHPVersion;
 
-const FUTURE = '9.315.319';
-const CURRENT = '8.335.362';
-const ACTUAL = '8.2.7';
+const FUTURE = '9.323.339';
+const CURRENT = '8.343.359';
+const ACTUAL = '8.2.8';


### PR DESCRIPTION
With the release of PHP 8.2.8 this packages needs updating. So this PR will bump current to 8.343.359 and future to 9.323.339.