### PR TITLE
[New Version] Update versions file to PHP 8.2.9

### DIFF
--- a/src/versions.php
+++ b/src/versions.php
@@ -2,6 +2,6 @@
 
 namespace WyriHaximus\FakePHPVersion;
 
-const FUTURE = '9.323.339';
-const CURRENT = '8.343.359';
-const ACTUAL = '8.2.8';
+const FUTURE = '9.325.332';
+const CURRENT = '8.345.388';
+const ACTUAL = '8.2.9';


### PR DESCRIPTION
With the release of PHP 8.2.9 this packages needs updating. So this PR will bump current to 8.345.388 and future to 9.325.332.