### PR TITLE
[New Version] Update versions file to PHP 8.2.10

### DIFF
--- a/src/versions.php
+++ b/src/versions.php
@@ -2,6 +2,6 @@
 
 namespace WyriHaximus\FakePHPVersion;
 
-const FUTURE = '9.325.332';
-const CURRENT = '8.345.388';
-const ACTUAL = '8.2.9';
+const FUTURE = '9.335.355';
+const CURRENT = '8.349.385';
+const ACTUAL = '8.2.10';


### PR DESCRIPTION
With the release of PHP 8.2.10 this packages needs updating. So this PR will bump current to 8.349.385 and future to 9.335.355.