### PR TITLE
[New Version] Update versions file to PHP 8.2.12

### DIFF
--- a/src/versions.php
+++ b/src/versions.php
@@ -2,6 +2,6 @@
 
 namespace WyriHaximus\FakePHPVersion;
 
-const FUTURE = '9.343.368';
-const CURRENT = '8.357.393';
-const ACTUAL = '8.2.11';
+const FUTURE = '9.351.367';
+const CURRENT = '8.363.393';
+const ACTUAL = '8.2.12';


### PR DESCRIPTION
With the release of PHP 8.2.12 this packages needs updating. So this PR will bump current to 8.363.393 and future to 9.351.367.