### PR TITLE
[New Version] Update versions file to PHP 8.2.13

### DIFF
--- a/src/versions.php
+++ b/src/versions.php
@@ -2,6 +2,6 @@
 
 namespace WyriHaximus\FakePHPVersion;
 
-const FUTURE = '9.351.367';
-const CURRENT = '8.363.393';
-const ACTUAL = '8.2.12';
+const FUTURE = '9.357.364';
+const CURRENT = '8.369.389';
+const ACTUAL = '8.2.13';


### PR DESCRIPTION
With the release of PHP 8.2.13 this packages needs updating. So this PR will bump current to 8.369.389 and future to 9.357.364.