### PR TITLE
[New Version] Update versions file to PHP 8.3.1

### DIFF
--- a/src/versions.php
+++ b/src/versions.php
@@ -2,6 +2,6 @@
 
 namespace WyriHaximus\FakePHPVersion;
 
-const FUTURE = '9.360.357';
-const CURRENT = '8.384.369';
-const ACTUAL = '8.3.0';
+const FUTURE = '9.369.363';
+const CURRENT = '8.399.386';
+const ACTUAL = '8.3.1';


### PR DESCRIPTION
With the release of PHP 8.3.1 this packages needs updating. So this PR will bump current to 8.399.386 and future to 9.369.363.