### PR TITLE
[New Version] Update versions file to PHP 8.3.3

### DIFF
--- a/src/versions.php
+++ b/src/versions.php
@@ -2,6 +2,6 @@
 
 namespace WyriHaximus\FakePHPVersion;
 
-const FUTURE = '9.375.377';
-const CURRENT = '8.402.409';
-const ACTUAL = '8.3.2';
+const FUTURE = '9.384.384';
+const CURRENT = '8.408.417';
+const ACTUAL = '8.3.3';


### PR DESCRIPTION
With the release of PHP 8.3.3 this packages needs updating. So this PR will bump current to 8.408.417 and future to 9.384.384.