### PR TITLE
[New Version] Update versions file to PHP 8.3.6

### DIFF
--- a/src/versions.php
+++ b/src/versions.php
@@ -2,6 +2,6 @@
 
 namespace WyriHaximus\FakePHPVersion;
 
-const FUTURE = '9.390.392';
-const CURRENT = '8.429.445';
-const ACTUAL = '8.3.5';
+const FUTURE = '9.402.414';
+const CURRENT = '8.438.453';
+const ACTUAL = '8.3.6';


### PR DESCRIPTION
With the release of PHP 8.3.6 this packages needs updating. So this PR will bump current to 8.438.453 and future to 9.402.414.