### PR TITLE
[New Version] Update versions file to PHP 8.3.8

### DIFF
--- a/src/versions.php
+++ b/src/versions.php
@@ -2,6 +2,6 @@
 
 namespace WyriHaximus\FakePHPVersion;
 
-const FUTURE = '9.408.423';
-const CURRENT = '8.444.473';
-const ACTUAL = '8.3.7';
+const FUTURE = '9.420.440';
+const CURRENT = '8.459.452';
+const ACTUAL = '8.3.8';


### PR DESCRIPTION
With the release of PHP 8.3.8 this packages needs updating. So this PR will bump current to 8.459.452 and future to 9.420.440.