### PR TITLE
[New Version] Update versions file to PHP 8.3.11

### DIFF
--- a/src/Versions.php
+++ b/src/Versions.php
@@ -4,7 +4,7 @@ namespace WyriHaximus\FakePHPVersion;
 
 final class Versions
 {
-    const FUTURE = '9.426.438';
-    const CURRENT = '8.468.486';
-    const ACTUAL = '8.3.9';
+    const FUTURE = '9.438.481';
+    const CURRENT = '8.480.501';
+    const ACTUAL = '8.3.11';
 }

--- a/src/versions.php
+++ b/src/versions.php
@@ -2,6 +2,6 @@
 
 namespace WyriHaximus\FakePHPVersion;
 
-const FUTURE = '9.426.438';
-const CURRENT = '8.468.486';
-const ACTUAL = '8.3.9';
+const FUTURE = '9.438.481';
+const CURRENT = '8.480.501';
+const ACTUAL = '8.3.11';


### PR DESCRIPTION
With the release of PHP 8.3.11 this packages needs updating. So this PR will bump current to 8.480.501 and future to 9.438.481.