### PR TITLE
[New Version] Update versions file to PHP 8.3.13

### DIFF
--- a/src/Versions.php
+++ b/src/Versions.php
@@ -4,7 +4,7 @@ namespace WyriHaximus\FakePHPVersion;
 
 final class Versions
 {
-    const FUTURE = '9.441.450';
-    const CURRENT = '8.495.528';
-    const ACTUAL = '8.3.12';
+    const FUTURE = '9.447.467';
+    const CURRENT = '8.498.560';
+    const ACTUAL = '8.3.13';
 }

--- a/src/versions.php
+++ b/src/versions.php
@@ -2,6 +2,6 @@
 
 namespace WyriHaximus\FakePHPVersion;
 
-const FUTURE = '9.441.450';
-const CURRENT = '8.495.528';
-const ACTUAL = '8.3.12';
+const FUTURE = '9.447.467';
+const CURRENT = '8.498.560';
+const ACTUAL = '8.3.13';


### PR DESCRIPTION
With the release of PHP 8.3.13 this packages needs updating. So this PR will bump current to 8.498.560 and future to 9.447.467.