### PR TITLE
[New Version] Update versions file to PHP 8.3.14

### DIFF
--- a/src/Versions.php
+++ b/src/Versions.php
@@ -4,7 +4,7 @@ namespace WyriHaximus\FakePHPVersion;
 
 final class Versions
 {
-    const FUTURE = '9.447.467';
-    const CURRENT = '8.498.560';
-    const ACTUAL = '8.3.13';
+    const FUTURE = '9.456.489';
+    const CURRENT = '8.504.526';
+    const ACTUAL = '8.3.14';
 }

--- a/src/versions.php
+++ b/src/versions.php
@@ -2,6 +2,6 @@
 
 namespace WyriHaximus\FakePHPVersion;
 
-const FUTURE = '9.447.467';
-const CURRENT = '8.498.560';
-const ACTUAL = '8.3.13';
+const FUTURE = '9.456.489';
+const CURRENT = '8.504.526';
+const ACTUAL = '8.3.14';


### PR DESCRIPTION
With the release of PHP 8.3.14 this packages needs updating. So this PR will bump current to 8.504.526 and future to 9.456.489.