### PR TITLE
[New Version] Update versions file to PHP 8.4.1

### DIFF
--- a/src/Versions.php
+++ b/src/Versions.php
@@ -4,7 +4,7 @@ namespace WyriHaximus\FakePHPVersion;
 
 final class Versions
 {
-    const FUTURE = '9.476.456';
-    const CURRENT = '8.524.504';
-    const ACTUAL = '8.4.0';
+    const FUTURE = '9.492.478';
+    const CURRENT = '8.544.527';
+    const ACTUAL = '8.4.1';
 }

--- a/src/versions.php
+++ b/src/versions.php
@@ -2,6 +2,6 @@
 
 namespace WyriHaximus\FakePHPVersion;
 
-const FUTURE = '9.476.456';
-const CURRENT = '8.524.504';
-const ACTUAL = '8.4.0';
+const FUTURE = '9.492.478';
+const CURRENT = '8.544.527';
+const ACTUAL = '8.4.1';


### PR DESCRIPTION
With the release of PHP 8.4.1 this packages needs updating. So this PR will bump current to 8.544.527 and future to 9.492.478.