### PR TITLE
[New Version] Update versions file to PHP 8.4.2

### DIFF
--- a/src/Versions.php
+++ b/src/Versions.php
@@ -4,7 +4,7 @@ namespace WyriHaximus\FakePHPVersion;
 
 final class Versions
 {
-    const FUTURE = '9.492.478';
-    const CURRENT = '8.544.527';
-    const ACTUAL = '8.4.1';
+    const FUTURE = '9.500.502';
+    const CURRENT = '8.552.548';
+    const ACTUAL = '8.4.2';
 }

--- a/src/versions.php
+++ b/src/versions.php
@@ -2,6 +2,6 @@
 
 namespace WyriHaximus\FakePHPVersion;
 
-const FUTURE = '9.492.478';
-const CURRENT = '8.544.527';
-const ACTUAL = '8.4.1';
+const FUTURE = '9.500.502';
+const CURRENT = '8.552.548';
+const ACTUAL = '8.4.2';


### PR DESCRIPTION
With the release of PHP 8.4.2 this packages needs updating. So this PR will bump current to 8.552.548 and future to 9.500.502.