### PR TITLE
[New Version] Update versions file to PHP 8.4.3

### DIFF
--- a/src/Versions.php
+++ b/src/Versions.php
@@ -4,7 +4,7 @@ namespace WyriHaximus\FakePHPVersion;
 
 final class Versions
 {
-    const FUTURE = '9.500.502';
-    const CURRENT = '8.552.548';
-    const ACTUAL = '8.4.2';
+    const FUTURE = '9.508.512';
+    const CURRENT = '8.568.561';
+    const ACTUAL = '8.4.3';
 }

--- a/src/versions.php
+++ b/src/versions.php
@@ -2,6 +2,6 @@
 
 namespace WyriHaximus\FakePHPVersion;
 
-const FUTURE = '9.500.502';
-const CURRENT = '8.552.548';
-const ACTUAL = '8.4.2';
+const FUTURE = '9.508.512';
+const CURRENT = '8.568.561';
+const ACTUAL = '8.4.3';


### PR DESCRIPTION
With the release of PHP 8.4.3 this packages needs updating. So this PR will bump current to 8.568.561 and future to 9.508.512.