### PR TITLE
[New Version] Update versions file to PHP 8.4.4

### DIFF
--- a/src/Versions.php
+++ b/src/Versions.php
@@ -4,7 +4,7 @@ namespace WyriHaximus\FakePHPVersion;
 
 final class Versions
 {
-    const FUTURE = '9.508.512';
-    const CURRENT = '8.568.561';
-    const ACTUAL = '8.4.3';
+    const FUTURE = '9.520.512';
+    const CURRENT = '8.588.580';
+    const ACTUAL = '8.4.4';
 }

--- a/src/versions.php
+++ b/src/versions.php
@@ -2,6 +2,6 @@
 
 namespace WyriHaximus\FakePHPVersion;
 
-const FUTURE = '9.508.512';
-const CURRENT = '8.568.561';
-const ACTUAL = '8.4.3';
+const FUTURE = '9.520.512';
+const CURRENT = '8.588.580';
+const ACTUAL = '8.4.4';


### PR DESCRIPTION
With the release of PHP 8.4.4 this packages needs updating. So this PR will bump current to 8.588.580 and future to 9.520.512.