### PR TITLE
[New Version] Update versions file to PHP 8.4.6

### DIFF
--- a/src/Versions.php
+++ b/src/Versions.php
@@ -4,7 +4,7 @@ namespace WyriHaximus\FakePHPVersion;
 
 final class Versions
 {
-    const FUTURE = '9.536.540';
-    const CURRENT = '8.608.593';
-    const ACTUAL = '8.4.5';
+    const FUTURE = '9.540.548';
+    const CURRENT = '8.624.614';
+    const ACTUAL = '8.4.6';
 }

--- a/src/versions.php
+++ b/src/versions.php
@@ -2,6 +2,6 @@
 
 namespace WyriHaximus\FakePHPVersion;
 
-const FUTURE = '9.536.540';
-const CURRENT = '8.608.593';
-const ACTUAL = '8.4.5';
+const FUTURE = '9.540.548';
+const CURRENT = '8.624.614';
+const ACTUAL = '8.4.6';


### PR DESCRIPTION
With the release of PHP 8.4.6 this packages needs updating. So this PR will bump current to 8.624.614 and future to 9.540.548.