### PR TITLE
[New Version] Update versions file to PHP 8.4.9

### DIFF
--- a/src/Versions.php
+++ b/src/Versions.php
@@ -4,7 +4,7 @@ namespace WyriHaximus\FakePHPVersion;
 
 final class Versions
 {
-    const FUTURE = '9.560.572';
-    const CURRENT = '8.644.640';
-    const ACTUAL = '8.4.8';
+    const FUTURE = '9.580.578';
+    const CURRENT = '8.656.671';
+    const ACTUAL = '8.4.9';
 }

--- a/src/versions.php
+++ b/src/versions.php
@@ -2,6 +2,6 @@
 
 namespace WyriHaximus\FakePHPVersion;
 
-const FUTURE = '9.560.572';
-const CURRENT = '8.644.640';
-const ACTUAL = '8.4.8';
+const FUTURE = '9.580.578';
+const CURRENT = '8.656.671';
+const ACTUAL = '8.4.9';


### PR DESCRIPTION
With the release of PHP 8.4.9 this packages needs updating. So this PR will bump current to 8.656.671 and future to 9.580.578.