### PR TITLE
[New Version] Update versions file to PHP 8.4.10

### DIFF
--- a/src/Versions.php
+++ b/src/Versions.php
@@ -4,7 +4,7 @@ namespace WyriHaximus\FakePHPVersion;
 
 final class Versions
 {
-    const FUTURE = '9.580.578';
-    const CURRENT = '8.656.671';
-    const ACTUAL = '8.4.9';
+    const FUTURE = '9.592.610';
+    const CURRENT = '8.668.676';
+    const ACTUAL = '8.4.10';
 }

--- a/src/versions.php
+++ b/src/versions.php
@@ -2,6 +2,6 @@
 
 namespace WyriHaximus\FakePHPVersion;
 
-const FUTURE = '9.580.578';
-const CURRENT = '8.656.671';
-const ACTUAL = '8.4.9';
+const FUTURE = '9.592.610';
+const CURRENT = '8.668.676';
+const ACTUAL = '8.4.10';


### PR DESCRIPTION
With the release of PHP 8.4.10 this packages needs updating. So this PR will bump current to 8.668.676 and future to 9.592.610.