### PR TITLE
[New Version] Update versions file to PHP 8.4.11

### DIFF
--- a/src/Versions.php
+++ b/src/Versions.php
@@ -4,7 +4,7 @@ namespace WyriHaximus\FakePHPVersion;
 
 final class Versions
 {
-    const FUTURE = '9.592.610';
-    const CURRENT = '8.668.676';
-    const ACTUAL = '8.4.10';
+    const FUTURE = '9.604.603';
+    const CURRENT = '8.688.701';
+    const ACTUAL = '8.4.11';
 }

--- a/src/versions.php
+++ b/src/versions.php
@@ -2,6 +2,6 @@
 
 namespace WyriHaximus\FakePHPVersion;
 
-const FUTURE = '9.592.610';
-const CURRENT = '8.668.676';
-const ACTUAL = '8.4.10';
+const FUTURE = '9.604.603';
+const CURRENT = '8.688.701';
+const ACTUAL = '8.4.11';


### PR DESCRIPTION
With the release of PHP 8.4.11 this packages needs updating. So this PR will bump current to 8.688.701 and future to 9.604.603.