### PR TITLE
[New Version] Update versions file to PHP 8.4.12

### DIFF
--- a/src/Versions.php
+++ b/src/Versions.php
@@ -4,7 +4,7 @@ namespace WyriHaximus\FakePHPVersion;
 
 final class Versions
 {
-    const FUTURE = '9.604.603';
-    const CURRENT = '8.688.701';
-    const ACTUAL = '8.4.11';
+    const FUTURE = '9.624.664';
+    const CURRENT = '8.696.748';
+    const ACTUAL = '8.4.12';
 }

--- a/src/versions.php
+++ b/src/versions.php
@@ -2,6 +2,6 @@
 
 namespace WyriHaximus\FakePHPVersion;
 
-const FUTURE = '9.604.603';
-const CURRENT = '8.688.701';
-const ACTUAL = '8.4.11';
+const FUTURE = '9.624.664';
+const CURRENT = '8.696.748';
+const ACTUAL = '8.4.12';


### PR DESCRIPTION
With the release of PHP 8.4.12 this packages needs updating. So this PR will bump current to 8.696.748 and future to 9.624.664.