### PR TITLE
[New Version] Update versions file to PHP 8.4.14

### DIFF
--- a/src/Versions.php
+++ b/src/Versions.php
@@ -4,7 +4,7 @@ namespace WyriHaximus\FakePHPVersion;
 
 final class Versions
 {
-    const FUTURE = '9.644.637';
-    const CURRENT = '8.708.709';
-    const ACTUAL = '8.4.13';
+    const FUTURE = '9.648.686';
+    const CURRENT = '8.728.750';
+    const ACTUAL = '8.4.14';
 }

--- a/src/versions.php
+++ b/src/versions.php
@@ -2,6 +2,6 @@
 
 namespace WyriHaximus\FakePHPVersion;
 
-const FUTURE = '9.644.637';
-const CURRENT = '8.708.709';
-const ACTUAL = '8.4.13';
+const FUTURE = '9.648.686';
+const CURRENT = '8.728.750';
+const ACTUAL = '8.4.14';


### PR DESCRIPTION
With the release of PHP 8.4.14 this packages needs updating. So this PR will bump current to 8.728.750 and future to 9.648.686.