### PR TITLE
[New Version] Update versions file to PHP 8.5.2

### DIFF
--- a/src/Versions.php
+++ b/src/Versions.php
@@ -4,7 +4,7 @@ namespace WyriHaximus\FakePHPVersion;
 
 final class Versions
 {
-    const FUTURE = '9.688.665';
-    const CURRENT = '8.738.737';
-    const ACTUAL = '8.5.1';
+    const FUTURE = '9.698.696';
+    const CURRENT = '8.758.746';
+    const ACTUAL = '8.5.2';
 }

--- a/src/versions.php
+++ b/src/versions.php
@@ -2,6 +2,6 @@
 
 namespace WyriHaximus\FakePHPVersion;
 
-const FUTURE = '9.688.665';
-const CURRENT = '8.738.737';
-const ACTUAL = '8.5.1';
+const FUTURE = '9.698.696';
+const CURRENT = '8.758.746';
+const ACTUAL = '8.5.2';


### PR DESCRIPTION
With the release of PHP 8.5.2 this packages needs updating. So this PR will bump current to 8.758.746 and future to 9.698.696.