### PR TITLE
[New Version] Update versions file to PHP 8.5.5

### DIFF
--- a/src/Versions.php
+++ b/src/Versions.php
@@ -4,7 +4,7 @@ namespace WyriHaximus\FakePHPVersion;
 
 final class Versions
 {
-    const FUTURE = '9.728.726';
-    const CURRENT = '8.783.793';
-    const ACTUAL = '8.5.4';
+    const FUTURE = '9.743.753';
+    const CURRENT = '8.808.788';
+    const ACTUAL = '8.5.5';
 }

--- a/src/versions.php
+++ b/src/versions.php
@@ -2,6 +2,6 @@
 
 namespace WyriHaximus\FakePHPVersion;
 
-const FUTURE = '9.728.726';
-const CURRENT = '8.783.793';
-const ACTUAL = '8.5.4';
+const FUTURE = '9.743.753';
+const CURRENT = '8.808.788';
+const ACTUAL = '8.5.5';


### PR DESCRIPTION
With the release of PHP 8.5.5 this packages needs updating. So this PR will bump current to 8.808.788 and future to 9.743.753.