### PR TITLE
[New Version] Update versions file to PHP 8.5.7

### DIFF
--- a/src/Versions.php
+++ b/src/Versions.php
@@ -4,7 +4,7 @@ namespace WyriHaximus\FakePHPVersion;
 
 final class Versions
 {
-    const FUTURE = '9.768.749';
-    const CURRENT = '8.818.826';
-    const ACTUAL = '8.5.6';
+    const FUTURE = '9.783.796';
+    const CURRENT = '8.823.832';
+    const ACTUAL = '8.5.7';
 }

--- a/src/versions.php
+++ b/src/versions.php
@@ -2,6 +2,6 @@
 
 namespace WyriHaximus\FakePHPVersion;
 
-const FUTURE = '9.768.749';
-const CURRENT = '8.818.826';
-const ACTUAL = '8.5.6';
+const FUTURE = '9.783.796';
+const CURRENT = '8.823.832';
+const ACTUAL = '8.5.7';


### PR DESCRIPTION
With the release of PHP 8.5.7 this packages needs updating. So this PR will bump current to 8.823.832 and future to 9.783.796.