### PR TITLE
[New Version] Update versions file to PHP 8.5.9

### DIFF
--- a/src/Versions.php
+++ b/src/Versions.php
@@ -4,7 +4,7 @@ namespace WyriHaximus\FakePHPVersion;
 
 final class Versions
 {
-    const FUTURE = '9.798.815';
-    const CURRENT = '8.833.839';
-    const ACTUAL = '8.5.8';
+    const FUTURE = '9.803.834';
+    const CURRENT = '8.838.851';
+    const ACTUAL = '8.5.9';
 }

--- a/src/versions.php
+++ b/src/versions.php
@@ -2,6 +2,6 @@
 
 namespace WyriHaximus\FakePHPVersion;
 
-const FUTURE = '9.798.815';
-const CURRENT = '8.833.839';
-const ACTUAL = '8.5.8';
+const FUTURE = '9.803.834';
+const CURRENT = '8.838.851';
+const ACTUAL = '8.5.9';


### PR DESCRIPTION
With the release of PHP 8.5.9 this packages needs updating. So this PR will bump current to 8.838.851 and future to 9.803.834.