### PR TITLE
[New Version] Update versions file to PHP 8.5.10

### DIFF
--- a/src/Versions.php
+++ b/src/Versions.php
@@ -4,7 +4,7 @@ namespace WyriHaximus\FakePHPVersion;
 
 final class Versions
 {
-    const FUTURE = '9.803.834';
-    const CURRENT = '8.838.851';
-    const ACTUAL = '8.5.9';
+    const FUTURE = '9.818.823';
+    const CURRENT = '8.853.888';
+    const ACTUAL = '8.5.10';
 }

--- a/src/versions.php
+++ b/src/versions.php
@@ -2,6 +2,6 @@
 
 namespace WyriHaximus\FakePHPVersion;
 
-const FUTURE = '9.803.834';
-const CURRENT = '8.838.851';
-const ACTUAL = '8.5.9';
+const FUTURE = '9.818.823';
+const CURRENT = '8.853.888';
+const ACTUAL = '8.5.10';


### PR DESCRIPTION
With the release of PHP 8.5.10 this packages needs updating. So this PR will bump current to 8.853.888 and future to 9.818.823.